### PR TITLE
Hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+abacus_env/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
Mismatching of metric function and metric name bug fix. New exception class created.
Bug description: when user uses a custom metric function name and doesn't assign the function evenly the library uses default function (np.mean) without any futher warnings. That may cause inapropriate experiment results. 
Solution: function and metric name match check. Raises an exception if not.